### PR TITLE
Handle POST 200 level requests

### DIFF
--- a/src/main/java/httpserver/request/RequestParser.java
+++ b/src/main/java/httpserver/request/RequestParser.java
@@ -3,10 +3,7 @@ package httpserver.request;
 import httpserver.interfaces.IRequestParser;
 import httpserver.models.Request;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 
 public class RequestParser implements IRequestParser {
    public BufferedReader reader;
@@ -19,6 +16,7 @@ public class RequestParser implements IRequestParser {
 
        setStartLine(startLine, requestBuilder);
        setHeaders(requestBuilder);
+       setBody(contentLength, requestBuilder);
        return requestBuilder.build();
     }
 
@@ -39,7 +37,6 @@ public class RequestParser implements IRequestParser {
                 String[] headerElements = headerLine.split(": ");
                 if (headerElements[0].equals("Content-Length")) {
                     contentLength = headerElements[1];
-                    setBody(contentLength, requestBuilder);
                 }
                 requestBuilder.addHeader(headerElements[0], headerElements[1]);
             }
@@ -47,13 +44,15 @@ public class RequestParser implements IRequestParser {
     }
 
     public void setBody(String contentLength, RequestBuilder requestBuilder) throws IOException {
-        if (contentLength.equals("0")) return;
-        String bodyLine;
-        StringBuilder body = new StringBuilder();
-        while ((bodyLine = reader.readLine()) != null) {
-            body.append(bodyLine + "\n");
+        if (contentLength != null && contentLength != "0") {
+            String parsedBod = null;
+            int bodyLength = Integer.parseInt(contentLength);
+            char[] destination = new char[bodyLength];
+            reader.read(destination, 0, bodyLength);
+            parsedBod = new String(destination, 0, bodyLength);
+
+            requestBuilder.setBody(parsedBod);
         }
-        requestBuilder.setBody(body.toString().trim());
     }
 
     public boolean isEmptyLine(String line) {

--- a/src/main/java/httpserver/response/ResponseBuilder.java
+++ b/src/main/java/httpserver/response/ResponseBuilder.java
@@ -1,5 +1,6 @@
 package httpserver.response;
 
+import httpserver.models.Request;
 import httpserver.models.Response;
 
 import java.util.Arrays;

--- a/src/main/java/httpserver/response/ResponseWriter.java
+++ b/src/main/java/httpserver/response/ResponseWriter.java
@@ -6,6 +6,9 @@ import httpserver.interfaces.IResponseWriter;
 import httpserver.models.Request;
 import httpserver.models.Response;
 
+import java.util.Date;
+import java.util.HashMap;
+
 public class ResponseWriter implements IResponseWriter {
 
     public Response buildSuccessResponse(Request request, String[] methods) {
@@ -16,12 +19,23 @@ public class ResponseWriter implements IResponseWriter {
                     .addHeader(Constants.ALLOW, methods)
                     .setBody("Hello world")
                     .build();
-        } else {
+            return response;
+        }
+
+        if (request.path.equals("/echo_body")) {
+            System.out.println(request.headers);
+            response = new ResponseBuilder()
+                    .setStatusCode(StatusCodes.SUCCESS)
+                    .addHeader(Constants.ALLOW, methods)
+                    .setBody(request.body)
+                    .build();
+            return response;
+        }
+
             response = new ResponseBuilder()
                     .setStatusCode(StatusCodes.SUCCESS)
                     .addHeader(Constants.ALLOW, methods)
                     .build();
-        }
         return response;
     }
 
@@ -56,6 +70,7 @@ public class ResponseWriter implements IResponseWriter {
             headers = stringifyHeaders(response);
             formattedResponse.append(headers);
             formattedResponse.append(response.body);
+            System.out.println(formattedResponse);
             return formattedResponse.toString();
         }
 

--- a/src/main/java/httpserver/router/Router.java
+++ b/src/main/java/httpserver/router/Router.java
@@ -22,6 +22,7 @@ public class Router implements IRouter {
         routes.put("/head_request", new String[]{Methods.HEAD, Methods.OPTIONS});
         routes.put("/method_options", new String[]{Methods.GET, Methods.HEAD, Methods.OPTIONS});
         routes.put("/method_options2", new String[]{Methods.GET, Methods.HEAD, Methods.OPTIONS, Methods.POST, Methods.PUT});
+        routes.put("/echo_body", new String[]{Methods.POST});
         return routes;
     }
 

--- a/src/test/java/httpserver/request/RequestParserTest.java
+++ b/src/test/java/httpserver/request/RequestParserTest.java
@@ -1,6 +1,7 @@
 package httpserver.request;
 
 import httpserver.models.Request;
+import httpserver.router.Router;
 import httpserver.utils.Methods;
 import httpserver.utils.Constants;
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,7 @@ public class RequestParserTest {
                         "Connection: close\n"  +
                         "Host: 127.0.0.1:5000\n" +
                         "User-Agent: http.rb/4.3.0\n" +
-                        "Content-Length: 0";
+                        "Content-Length: 0" + Constants.DOUBLE_LINE_BREAK;
 
         InputStream requestStream = new ByteArrayInputStream(request.getBytes());
 
@@ -35,7 +36,7 @@ public class RequestParserTest {
         assertEquals("/simple_get_with_body", formattedRequest.path);
         assertEquals(Constants.PROTOCOL, formattedRequest.protocol);
         assertEquals(headers, formattedRequest.headers);
-        assertNull(formattedRequest.body);
+        assertEquals("", formattedRequest.body);
     }
 
     @Test
@@ -44,7 +45,7 @@ public class RequestParserTest {
                 "Connection: close\n" +
                 "Host: 127.0.0.1:5000\n" +
                 "User-Agent: http.rb/4.3.0\n" +
-                "Content-Length: 0";
+                "Content-Length: 0" + Constants.DOUBLE_LINE_BREAK;
         InputStream headersBytes = new ByteArrayInputStream(headers.getBytes());
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.put("Connection", "close");
@@ -67,8 +68,7 @@ public class RequestParserTest {
                 "Connection: close\n" +
                         "Host: 127.0.0.1:5000\n" +
                         "User-Agent: http.rb/4.3.0\n" +
-                        "Content-Length: 0" +
-                        "\n";
+                        "Content-Length: 0" + Constants.DOUBLE_LINE_BREAK;
         InputStream headersBytes = new ByteArrayInputStream(headers.getBytes());
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.put("Connection", "close");
@@ -92,7 +92,7 @@ public class RequestParserTest {
                         "Connection: close\n"  +
                         "Host: 127.0.0.1:5000\n" +
                         "User-Agent: http.rb/4.3.0\n" +
-                        "Content-Length: 11\r\n\r\n" +
+                        "Content-Length: 9" + Constants.DOUBLE_LINE_BREAK +
                         "Body Line";
         InputStream requestBytes = new ByteArrayInputStream(requestWithBody.getBytes());
         RequestParser parser = new RequestParser();
@@ -106,8 +106,7 @@ public class RequestParserTest {
     public void setsBodyToNullWhenRequestDoesNotIncludeBody() throws IOException {
         String headers =
                         "Host: 127.0.0.1:5000\n" +
-                        "Content-Length: 0\n" +
-                        "\n";
+                        "Content-Length: 0" + Constants.DOUBLE_LINE_BREAK;
         InputStream headersBytes = new ByteArrayInputStream(headers.getBytes());
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.put("Host", "127.0.0.1:5000");

--- a/src/test/java/httpserver/response/ResponseWriterTest.java
+++ b/src/test/java/httpserver/response/ResponseWriterTest.java
@@ -8,7 +8,10 @@ import httpserver.utils.StatusCodes;
 import httpserver.utils.Constants;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResponseWriterTest {
     @Test


### PR DESCRIPTION
- Handle POST 200 level requests
- Refactors `setBody` in `RequestParser` to use `read()` instead of `readLine()`