### PR TITLE
Handle GET request with 200 level JSON response

### DIFF
--- a/src/main/java/httpserver/response/ResponseWriter.java
+++ b/src/main/java/httpserver/response/ResponseWriter.java
@@ -16,7 +16,6 @@ public class ResponseWriter implements IResponseWriter {
         if (request.path.equals("/simple_get_with_body")) {
             response = new ResponseBuilder()
                     .setStatusCode(StatusCodes.SUCCESS)
-                    .addHeader(Constants.ALLOW, stringifyMethods(methods))
                     .setBody("Hello world")
                     .build();
             return response;
@@ -52,6 +51,15 @@ public class ResponseWriter implements IResponseWriter {
                     .setStatusCode(StatusCodes.SUCCESS)
                     .addHeader(Constants.TYPE, "text/html;charset=utf-8")
                     .setBody("<html><body><p>HTML Response</p></body></html>")
+                    .build();
+            return response;
+        }
+
+        if (request.path.equals("/json_response")) {
+            response = new ResponseBuilder()
+                    .setStatusCode(StatusCodes.SUCCESS)
+                    .addHeader(Constants.TYPE, "application/json;charset=utf-8")
+                    .setBody("{\"key1\":\"value1\",\"key2\":\"value2\"}")
                     .build();
             return response;
         }

--- a/src/main/java/httpserver/router/Router.java
+++ b/src/main/java/httpserver/router/Router.java
@@ -26,6 +26,7 @@ public class Router implements IRouter {
         routes.put("/redirect", new String[]{Methods.GET});
         routes.put("/text_response", new String[]{Methods.GET});
         routes.put("/html_response", new String[]{Methods.GET});
+        routes.put("/json_response", new String[]{Methods.GET});
         return routes;
     }
 

--- a/src/test/java/httpserver/response/ResponseWriterTest.java
+++ b/src/test/java/httpserver/response/ResponseWriterTest.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ResponseWriterTest {
+
     @Test
     public void returnsA200OKResponse() {
         IResponseWriter responseWriter = new ResponseWriter();
@@ -49,10 +50,10 @@ public class ResponseWriterTest {
     @Test
     public void createsFormattedResponseWithHeadersAndBody() {
         ResponseWriter responseWriter = new ResponseWriter();
-        Request request = new Request(Methods.GET,"/simple_get_with_body", Constants.PROTOCOL, null, null);
+        Request request = new Request(Methods.GET,"/text_response", Constants.PROTOCOL, null, null);
         Response response = responseWriter.buildSuccessResponse(request, new String[]{request.method});
-        String headers = Constants.ALLOW + ": " + Methods.GET;
-        String expectedResponse = Constants.PROTOCOL + " " + StatusCodes.SUCCESS + Constants.LINE_BREAK + headers + Constants.LINE_BREAK + Constants.LINE_BREAK + "Hello world";
+        String headers = Constants.TYPE + ": text/plain;charset=utf-8";
+        String expectedResponse = Constants.PROTOCOL + " " + StatusCodes.SUCCESS + Constants.LINE_BREAK + headers + Constants.LINE_BREAK + Constants.LINE_BREAK + "text response";
 
         String formattedResponse = responseWriter.formatResponse(response);
 


### PR DESCRIPTION
- Handles GET request with 200 level response with a JSON body
- Removes unnecessary header from `/simple_get_with_body` route
- Updates `createsFormattedResponseWithHeadersAndBody()` test to use `/json_response` as a route